### PR TITLE
Curator artwork grid and artwork page

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,6 +1,9 @@
+$enable-important-utilities: false;
+
 @import "bootstrap/scss/bootstrap";
 @import "bootstrap-icons/font/bootstrap-icons";
 // @import "rails_bootstrap_forms";
+
 
 .navbar img {
   display: inline; // for tw/bs compatibility. remove when navbar is migrated to tw

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,10 +5,23 @@
 
 
 @layer components {
+  a {
+    @apply text-slate-600 hover:underline hover:text-slate-500 no-underline
+  }
+
+  .tw-btn-primary {
+    @apply px-2 py-1 border text-slate-700 bg-slate-200 hover:text-black hover:border-black 
+       border-slate-700 rounded-md text-nowrap no-underline;
+  }
+
   .tw-btn-secondary {
-    @apply px-2 py-1 border text-black hover:text-slate-600 hover:border-slate-400 rounded
-       border-black px-2 py-1 border text-black hover:text-slate-600 hover:border-slate-400 
-       rounded-md border-black text-nowrap;
+    @apply px-2 py-1 border text-black hover:text-slate-600 hover:border-slate-400 
+       border-black rounded-md text-nowrap no-underline;
+  }
+
+  .tw-btn-danger {
+    @apply px-2 py-1 border text-red-800 hover:text-red-600 border-red-800 
+        hover:border-red-400 rounded-md text-nowrap no-underline;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,17 @@
 module ApplicationHelper
   def thumbnail_url(image)
-    if image.is_video?
+    if image&.is_video?
       "#{image.file.url}/ik-thumbnail.jpg?tr=h-100"
     else
-      image.file.url(transformation: [{height: 100, width: 100, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
+      image&.file&.url(transformation: [{height: 100, width: 100, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
     end
   end
 
   def large_url(image)
-    if image.is_video?
+    if image&.is_video?
       "#{image.file.url}/ik-thumbnail.jpg?tr=h-400,w=400,c-maintain_ratio"
     else
-      image.file.url(transformation: [{height: 400, width: 400, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
+      image&.file&.url(transformation: [{height: 400, width: 400, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,17 @@
 module ApplicationHelper
   def thumbnail_url(image)
-    if image&.is_video?
+    if image.is_video?
       "#{image.file.url}/ik-thumbnail.jpg?tr=h-100"
     else
-      image&.file&.url(transformation: [{height: 100, width: 100, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
+      image.file.url(transformation: [{height: 100, width: 100, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
     end
   end
 
   def large_url(image)
-    if image&.is_video?
+    if image.is_video?
       "#{image.file.url}/ik-thumbnail.jpg?tr=h-400,w=400,c-maintain_ratio"
     else
-      image&.file&.url(transformation: [{height: 400, width: 400, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
+      image.file.url(transformation: [{height: 400, width: 400, quality: 100, raw: "c-at_max,c-maintain_ratio"}])
     end
   end
 

--- a/app/javascript/carousel.js
+++ b/app/javascript/carousel.js
@@ -1,6 +1,8 @@
-const BUTTON_ACTIVE_CLASS = "bg-slate-300";
+// TODO: animation. source: https://tw-elements.com/docs/standard/components/carousel/
+
+const BUTTON_ACTIVE_CLASS = "!opacity-100";
 const INACTIVE_CLASSES = ["hidden"];
-const ACTIVE_CLASSES = [];
+const ACTIVE_CLASSES = [] //"!block"];
 
 const containers = document.querySelectorAll("[data-carousel]");
 
@@ -23,10 +25,12 @@ containers.forEach((container) => {
   const activateIndex = (index) => {
     if (prevIndex !== -1) {
       items[prevIndex].classList.add(INACTIVE_CLASSES);
+      // items[prevIndex].classList.remove(ACTIVE_CLASSES);
       buttons[prevIndex].classList.remove(BUTTON_ACTIVE_CLASS);
     }
     if (index < itemsCount) {
       items[index].classList.remove(INACTIVE_CLASSES);
+      // items[index].classList.add(ACTIVE_CLASSES);
       buttons[index].classList.add(BUTTON_ACTIVE_CLASS);
     }
   };

--- a/app/javascript/carousel.js
+++ b/app/javascript/carousel.js
@@ -1,0 +1,55 @@
+const BUTTON_ACTIVE_CLASS = "bg-slate-300";
+const INACTIVE_CLASSES = ["hidden"];
+const ACTIVE_CLASSES = [];
+
+const containers = document.querySelectorAll("[data-carousel]");
+
+containers.forEach((container) => {
+  const nextBtn = container.querySelector("button[data-carousel-next]");
+  const prevBtn = container.querySelector("button[data-carousel-prev]");
+  const items = container.querySelectorAll("[data-carousel-item]");
+  const buttons = container.querySelectorAll("[data-carousel-slide-to]");
+
+  const itemsCount = items.length;
+
+  let index = 0;
+  let prevIndex = -1;
+
+  const init = () => {
+    if (itemsCount > -1) {
+      activateIndex(0);
+    }
+  };
+  const activateIndex = (index) => {
+    if (prevIndex !== -1) {
+      items[prevIndex].classList.add(INACTIVE_CLASSES);
+      buttons[prevIndex].classList.remove(BUTTON_ACTIVE_CLASS);
+    }
+    if (index < itemsCount) {
+      items[index].classList.remove(INACTIVE_CLASSES);
+      buttons[index].classList.add(BUTTON_ACTIVE_CLASS);
+    }
+  };
+
+  init();
+
+  buttons.forEach((button) =>
+    button.addEventListener("click", (event) => {
+      prevIndex = index;
+      index = event.target.dataset.carouselSlideTo;
+      activateIndex(index);
+    })
+  );
+
+  nextBtn.addEventListener("click", () => {
+    prevIndex = index;
+    index = (index + 1) % itemsCount;
+    activateIndex(index);
+  });
+
+  prevBtn.addEventListener("click", () => {
+    prevIndex = index;
+    index = index === 0 ? itemsCount - 1 : index - 1;
+    activateIndex(index);
+  });
+});

--- a/app/views/artworks/_artwork.html.erb
+++ b/app/views/artworks/_artwork.html.erb
@@ -12,7 +12,7 @@
         <% end %>
       </td>
       <td>
-        <%= button_to "Delete", artwork, method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class: "btn btn-sm btn-danger" %>
+        <%= button_to "Delete", artwork, method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class: "tw-btn-danger" %>
       </td>
     </tr>
   </div>

--- a/app/views/artworks/_dimensions.html.erb
+++ b/app/views/artworks/_dimensions.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="text-slate-500">
   <% if @artwork.duration %>
     <%= @artwork.duration %> minutes <br>
   <% end %>

--- a/app/views/artworks/_form.html.erb
+++ b/app/views/artworks/_form.html.erb
@@ -16,5 +16,5 @@
     <%= f.number_field :width %>
     <%= f.number_field :depth %>
   </fieldset>
-  <%= f.submit "Save" %>
+  <%= f.submit "Save", class: "tw-btn-primary" %>
 <% end %>

--- a/app/views/artworks/_image.html.erb
+++ b/app/views/artworks/_image.html.erb
@@ -1,5 +1,5 @@
 <div class="col-4">
   <%= image_tag large_url(i), alt: i.caption %>
   <i><%= i.caption %></i>
-  <%= button_to asset_delete_text(i), [@artwork, i], method: :delete, class: "btn btn-danger btn-sm mt-2 mb-4", form: { data: { turbo_confirm: 'Are you sure?' } } %>
+  <%= button_to asset_delete_text(i), [@artwork, i], method: :delete, class: "tw-btn-danger btn-sm mt-2 mb-4", form: { data: { turbo_confirm: 'Are you sure?' } } %>
 </div>

--- a/app/views/artworks/show.html.erb
+++ b/app/views/artworks/show.html.erb
@@ -48,8 +48,8 @@
       <% end%>
     </div>
     <div class="col-4 mt-2">
-      <%= link_to "Edit this artwork", edit_artwork_path(@artwork), class: "btn btn-primary mb-4" %>
-      <%= button_to "Delete this artwork", @artwork, method: :delete, class: "btn btn-danger", form: { data: { turbo_confirm: 'Are you sure?' } }, class: "btn btn-danger mt-4" %>
+      <%= link_to "Edit this artwork", edit_artwork_path(@artwork), class: "tw-btn-secondary" %>
+      <%= button_to "Delete this artwork", @artwork, method: :delete, class: "tw-btn-danger", form: { data: { turbo_confirm: 'Are you sure?' } }, class: "tw-btn-danger mt-4" %>
     </div>
   </div>
 </div>

--- a/app/views/curator/artworks/_artwork.html.erb
+++ b/app/views/curator/artworks/_artwork.html.erb
@@ -1,12 +1,10 @@
-<div class="row border-bottom my-4 py-4">
-  <div class="col-1"><%= artwork.id %></div>
-  <div class="col-2"><%= artwork.user.name %></div>
-  <div class="col-3"><%= link_to artwork.title, curator_artwork_url(artwork) %></div>
-  <div class="col-1"><%= artwork.medium %></div>
-  <div class="col-2"><%= artwork.description %></div>
-  <div class="col-3">
-    <% artwork.images.each do |image| %>
-      <%= image_tag thumbnail_url(image)  %>
-    <% end %>
-  </div>
+<div>
+    <a class="text-black" href="<%= curator_artwork_url(artwork) %>">
+      <img class="h-auto max-w-full" src="<%= large_url(artwork.images.first) if artwork.images.length %>" alt="<%= artwork.title %>">
+      <section class="pt-2">
+        <div class=""><%= artwork.user.name %></div>
+        <div class="text-gray-500 italic"><%= artwork.title %></div>
+        <div class=" text-sm text-gray-700"><%= artwork.description %></div>
+      </section>
+    </a>
 </div>

--- a/app/views/curator/artworks/index.html.erb
+++ b/app/views/curator/artworks/index.html.erb
@@ -15,7 +15,6 @@
 </div>
 
 <% 
-  # number_of_cols = 4
   items_per_column = @artworks.length / 4 + 1 # TODO: better formula
 
 %>

--- a/app/views/curator/artworks/index.html.erb
+++ b/app/views/curator/artworks/index.html.erb
@@ -14,9 +14,29 @@
   </div>
 </div>
 
-<div class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-    <% @artworks.each do |artwork| %>
-      <%= render artwork %>
-    <% end %>
+<% 
+  # number_of_cols = 4
+  items_per_column = @artworks.length / 4 + 1 # TODO: better formula
+
+%>
+
+<div class="flex justify-center">
+  <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 ">
+      <% @artworks.each_with_index do |artwork, index| %>
+        <% if index % items_per_column == 0 %>
+          <div class="grid gap-4 content-baseline">
+        <% end %>
+            <%= render artwork %>
+        <% if index % items_per_column == items_per_column - 1 %>
+          </div>
+        <% end %>
+
+      <% end %>
+
+  </div>
+</div>
+
+
+
 
 </div>

--- a/app/views/curator/artworks/index.html.erb
+++ b/app/views/curator/artworks/index.html.erb
@@ -1,18 +1,22 @@
-<div class="row my-4 border-bottom">
+<div class="row">
   <div class="col-4">
     <h4>Artworks</h4>
     <%= paginate @artworks %>
   </div>
   <div class="col-4">&nbsp </div>
-  <div class="col-4 mb-3">
+  <div class="col-4">
     <%= bootstrap_form_tag method: :get do |f| %>
-      <%= f.text_field :search, value: @search_term  %>
+      <%= f.text_field :search, value: @search_term, placeholder: "search", label: '&nbsp;'.html_safe   %>
     <% end %>
     <% if @search_term.present? %>
       <%= link_to "clear search", curator_artworks_path %>
     <% end %>
   </div>
 </div>
-<% @artworks.each do |artwork| %>
-  <%= render artwork %>
-<% end %>
+
+<div class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <% @artworks.each do |artwork| %>
+      <%= render artwork %>
+    <% end %>
+
+</div>

--- a/app/views/curator/artworks/show.html.erb
+++ b/app/views/curator/artworks/show.html.erb
@@ -1,5 +1,5 @@
 
-<div class="grid grid-cols-1 grid-rows-3 lg:grid-rows-3 lg:grid-cols-4 gap-5 h-auto">
+<div class="flex flex-col lg:grid lg:grid-rows-3 lg:grid-cols-4 gap-6 h-auto">
   <div class="lg:col-span-3 lg:row-span-2">
 
     <div
@@ -98,7 +98,7 @@
         
   </div>
 
-  <div class="row-start-2 lg:row-start-1 col-start-1 lg:col-start-4 lg:row-span-2">
+  <div class="lg:row-start-1 lg:col-start-4 lg:row-span-2">
     <div class="">
       <h1 class="text-2xl mb-0 font-normal">
         <%= @artwork.user.name %>
@@ -129,7 +129,7 @@
       <% end%>
     </div>
   </div>
-  <section class="col-span-1 row-start-3 lg:col-span-3 lg:row-start-3 lg:row-span-4">
+  <section class="lg:col-span-3 lg:row-start-3 lg:row-span-4">
       <div class="pb-2">
       About artist:
       </div>

--- a/app/views/curator/artworks/show.html.erb
+++ b/app/views/curator/artworks/show.html.erb
@@ -1,54 +1,102 @@
 
-<div class="grid grid-cols-1 grid-rows-3 lg:grid-rows-3 lg:grid-cols-4 gap-5 h-auto lg:h-screen">
+<div class="grid grid-cols-1 grid-rows-3 lg:grid-rows-3 lg:grid-cols-4 gap-5 h-auto">
   <div class="lg:col-span-3 lg:row-span-2">
 
+    <div
+      id="default-carousel"
+      data-carousel="slide"
+      class="relative">
 
 
+      <!--Carousel items-->
+      <div
+        class="relative w-full overflow-hidden after:clear-both after:block after:content-['']">
+        <% @artwork.images.each_with_index do | image, i | %>
+        <a data-fslightbox href="<%= image.file.url %>">
+          <div
+            class="relative float-left -mr-[100%] w-full transition-transform duration-[600ms] 
+            ease-in-out motion-reduce:transition-none <%= "!block" if i == 0 %>"
+            data-carousel-item
+            style="backface-visibility: hidden">
+            <%= image_tag image.file.url, alt: image.caption, class: "block w-full" %>
+            <div
+              class="absolute inset-x-[15%] bottom-0 hidden py-5 text-center text-white md:block">
+              <h5 class="text-slate-200"><%= image.caption %></h5>
 
-    <div id="default-carousel" class="w-full h-full overflow-y-hidden" data-carousel="slide">
-        <!-- Carousel wrapper -->
-        <div class="relative h-full">
-          <div class="relative rounded">
-              <% @artwork.images.each do |image| %>
-              <a data-fslightbox href="<%= image.file.url %>">
-                <div class="hidden duration-700 ease-in-out" data-carousel-item>
-                  <%= image_tag image.file.url, alt: image.caption, class: "absolute block w-full -translate-x-1/2  left-1/2" %>
-                  
-                </div>
-              </a>
-              <% end %>
+            </div>
+          </div>    
+        </a>
+        <% end %>    
+        
+      <% if @artwork.images.length > 1 %>
+      <!--Carousel indicators-->
+      <div
+        class="absolute bottom-6 left-0 right-0 z-[2] mx-[15%] mb-4 flex list-none justify-center p-0"
+        data-twe-carousel-indicators>
+        <% @artwork.images.each_with_index do |artwork, i| %>
+          <button
+            type="button"
+            aria-label="Slide <%= i %>" data-carousel-slide-to="<%= i %>"
+            class="mx-[3px] box-content h-[3px] w-[30px] flex-initial cursor-pointer 
+                  border-0 border-y-[10px] border-solid border-transparent bg-white
+                  bg-clip-padding p-0 -indent-[999px] opacity-50 transition-opacity
+                  duration-[600ms] ease-[cubic-bezier(0.25,0.1,0.25,1.0)] motion-reduce:transition-none <%= '!opacity-100' if i == 0 %>"></button>
+        <% end %>
+      </div>        
 
-          </div>
-          <% if @artwork.images.length > 1  %>
-          <!-- Slider indicators -->
-          <div class="absolute z-30 flex -translate-x-1/2 bottom-2 left-1/2 space-x-3 rtl:space-x-reverse">
-              <% @artwork.images.each_with_index do |artwork, i| %>
-                <button type="button" class="w-3 h-3 rounded-full bg-slate-100 border border-slate-500" aria-current="true" aria-label="Slide <%= i %>" data-carousel-slide-to="<%= i %>"></button>
-              <% end %>
-          </div>
-          <!-- Slider controls -->
-          <button type="button" class="absolute top-0 start-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-prev>
-              <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-1 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
-                  <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
-                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 1 1 5l4 4"/>
-                  </svg>
-                  <span class="sr-only">Previous</span>
-              </span>
-          </button>
-          <button type="button" class="absolute top-0 end-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-next>
-              <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-1 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
-                  <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
-                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
-                  </svg>
-                  <span class="sr-only">Next</span>
-              </span>
-          </button>
-          <% end %>
-      </div>
+      <!--Carousel controls - prev item-->
+      <button
+        class="absolute bottom-0 left-0 top-0 z-[1] flex w-[15%] items-center justify-center border-0 bg-none p-0 text-center text-white opacity-50 transition-opacity duration-150 ease-[cubic-bezier(0.25,0.1,0.25,1.0)] hover:text-white hover:no-underline hover:opacity-90 hover:outline-none focus:text-white focus:no-underline focus:opacity-90 focus:outline-none motion-reduce:transition-none"
+        type="button"
+        data-carousel-prev>
+        <span class="inline-block h-8 w-8">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="h-6 w-6">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+        </span>
+        <span
+          class="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
+          >Previous</span
+        >
+      </button>
+      <!--Carousel controls - next item-->
+      <button
+        class="absolute bottom-0 right-0 top-0 z-[1] flex w-[15%] items-center justify-center border-0 bg-none p-0 text-center text-white opacity-50 transition-opacity duration-150 ease-[cubic-bezier(0.25,0.1,0.25,1.0)] hover:text-white hover:no-underline hover:opacity-90 hover:outline-none focus:text-white focus:no-underline focus:opacity-90 focus:outline-none motion-reduce:transition-none"
+        type="button"
+        data-carousel-next>
+        <span class="inline-block h-8 w-8">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="h-6 w-6">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+          </svg>
+        </span>
+        <span
+          class="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
+          >Next</span
+        >
+      </button>
+      <% end %>
     </div>
+   </div>
+        
   </div>
-
-
 
   <div class="row-start-2 lg:row-start-1 col-start-1 lg:col-start-4 lg:row-span-2">
     <div class="">

--- a/app/views/curator/artworks/show.html.erb
+++ b/app/views/curator/artworks/show.html.erb
@@ -1,41 +1,93 @@
-<div class="container">
-  <section class="image-grid mt-2">
-    <div class="row gy-4">
-      <% @artwork.images.each do |i| %>
-        <div class="col-4">
-          <a data-fslightbox href="<%= i.file.url %>">
-            <%= image_tag large_url(i), alt: i.caption %>
-          </a>
-          <br>
-          <i><%= i.caption %></i>
-        </div>
-      <% end %>
+
+<div class="grid grid-cols-1 grid-rows-3 lg:grid-rows-3 lg:grid-cols-4 gap-5 h-auto lg:h-screen">
+  <div class="lg:col-span-3 lg:row-span-2">
+
+
+
+
+    <div id="default-carousel" class="w-full h-full overflow-y-hidden" data-carousel="slide">
+        <!-- Carousel wrapper -->
+        <div class="relative h-full">
+          <div class="relative rounded">
+              <% @artwork.images.each do |image| %>
+              <a data-fslightbox href="<%= image.file.url %>">
+                <div class="hidden duration-700 ease-in-out" data-carousel-item>
+                  <%= image_tag image.file.url, alt: image.caption, class: "absolute block w-full -translate-x-1/2  left-1/2" %>
+                  
+                </div>
+              </a>
+              <% end %>
+
+          </div>
+          <% if @artwork.images.length > 1  %>
+          <!-- Slider indicators -->
+          <div class="absolute z-30 flex -translate-x-1/2 bottom-2 left-1/2 space-x-3 rtl:space-x-reverse">
+              <% @artwork.images.each_with_index do |artwork, i| %>
+                <button type="button" class="w-3 h-3 rounded-full bg-slate-100 border border-slate-500" aria-current="true" aria-label="Slide <%= i %>" data-carousel-slide-to="<%= i %>"></button>
+              <% end %>
+          </div>
+          <!-- Slider controls -->
+          <button type="button" class="absolute top-0 start-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-prev>
+              <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-1 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
+                  <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 1 1 5l4 4"/>
+                  </svg>
+                  <span class="sr-only">Previous</span>
+              </span>
+          </button>
+          <button type="button" class="absolute top-0 end-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-next>
+              <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-1 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
+                  <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+                      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
+                  </svg>
+                  <span class="sr-only">Next</span>
+              </span>
+          </button>
+          <% end %>
+      </div>
     </div>
-  </section>
-  <div class="row mt-4">
-    <div class="col-6">
-      <div><strong><%= @artwork.title %></strong> (<%= @artwork.year %>) by <%= @artwork.user.name %><br>
+  </div>
+
+
+
+  <div class="row-start-2 lg:row-start-1 col-start-1 lg:col-start-4 lg:row-span-2">
+    <div class="">
+      <h1 class="text-2xl mb-0 font-normal">
+        <%= @artwork.user.name %>
+      </h1>
+      <h2 class="text-2xl font-normal italic text-slate-500">
+        <%= @artwork.title %>, (<%= @artwork.year %>)
+      </h2>
+      <div class="text-slate-500">
         <%= @artwork.medium %>
       </div>
       <% if @artwork.edition.present? %>
-        <div>
+        <div class="text-slate-500">
           ed: <%= @artwork.edition %>
         </div>
       <% end %>
       <%= render "artworks/dimensions" %>
-      <div>
+      <div class="text-slate-500">
         Location: <%= @artwork.location %>
       </div>
-      <div>
-        Price: <%= @artwork.price.present? ? @artwork.price : "none" %>
+      <div class="text-2xl py-2">
+        Price: <%= @artwork.price.present? ? @artwork.price : "N/A" %>
       </div>
       <% if @artwork.description.present? %>
-        <div class="mt-2">
+        <div class="mt-2 text-slate-500">
           <div class="fw-bold">Description</div>
           <%= @artwork.description %>
         </div>
       <% end%>
     </div>
   </div>
+  <section class="col-span-1 row-start-3 lg:col-span-3 lg:row-start-3 lg:row-span-4">
+      <div class="pb-2">
+      About artist:
+      </div>
+      <%= @artwork.user.profile&.bio %>
+  </section>  
 </div>
+
 <%= javascript_include_tag "lightbox-refresh" %>
+<%= javascript_include_tag "carousel" %>

--- a/app/views/curator/artworks/show.html.erb
+++ b/app/views/curator/artworks/show.html.erb
@@ -20,7 +20,7 @@
             style="backface-visibility: hidden">
             <%= image_tag image.file.url, alt: image.caption, class: "block w-full" %>
             <div
-              class="absolute inset-x-[15%] bottom-0 hidden py-5 text-center text-white md:block">
+              class="absolute inset-x-[15%] bottom-0 py-5 text-center text-white block">
               <h5 class="text-slate-200"><%= image.caption %></h5>
 
             </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit "Resend confirmation instructions", class: "tw-btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,6 +4,6 @@
     <%= f.hidden_field :reset_password_token %>
     <%= f.password_field :password, label: "New password", autofocus: true %>
     <%= f.password_field :password_confirmation, label: "Confirm new password" %>
-    <%= f.submit "Change my password" %>
+    <%= f.submit "Change my password", class: "tw-btn-primary" %>
   <% end %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,7 +5,7 @@
     <div class="field">
       <%= f.email_field :email, autofocus: true, autocomplete: "email", label: "E-mail address"  %>
     </div>
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "Send me reset password instructions", class: "tw-btn-primary" %>
   <% end %>
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "Update", class: "tw-btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "Sign up", class: "tw-btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
     <%= f.email_field :email, label: "E-mail address" %>
     <%= f.password_field :password %>
     <%= f.check_box :remember_me %>
-    <%= f.submit "Log In" %>
+    <%= f.submit "Log In", class: "tw-btn-primary" %>
   <% end %>
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit "Resend unlock instructions", class: "tw-btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -2,5 +2,5 @@
   <%= f.alert_message "Please fix the errors below." %>
   <%= f.text_field :caption, label: "Caption", class: "form-control-sm", help: "required" %>
   <%= f.file_field :file, class: "form-control-sm" %>
-  <%= f.submit "Save" %>
+  <%= f.submit "Save", class: "tw-btn-primary" %>
 <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,7 +4,7 @@
 
       <div class="flex flex-1 items-center justify-between sm:items-stretch ">
         <div class="flex flex-shrink-0 items-center">
-          <a class="flex items-center" href="/">
+          <a class="flex items-center hover:no-underline" href="/">
             <img class="h-8 w-auto" src="/logo.png" alt="Netvvrk Members Database" >
             <span class="px-2 text-black">Netvvrk Members Database</span>
           </a>
@@ -19,13 +19,13 @@
             <div class="flex lg:flex-1 flex-col pt-12 lg:pt-0 lg:flex-row">
             <% if user_signed_in? %>
               <% if current_user.show_artworks? %>
-                <%= link_to "Artworks", artworks_url, class: "text-black hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
+                <%= link_to "Artworks", artworks_url, class: "text-black hover:no-underline hover:text-slate-600 hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
               <% end %>
               <% if current_user.show_browse? %>
-                <%= link_to "Browse Artworks", curator_artworks_url, class: "text-black hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
+                <%= link_to "Browse Artworks", curator_artworks_url, class: "text-black hover:no-underline hover:text-slate-600 hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
               <% end %>
               <% if current_user.show_users? %>
-                <%= link_to "Users", users_url, class: "text-black hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
+                <%= link_to "Users", users_url, class: "text-black hover:no-underline hover:text-slate-600 hover:text-black rounded-md px-3 py-2 text-base font-medium" %>
               <% end %>
 
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   </head>
   <body>
     <%= render "layouts/navbar" %>
-    <div class="container px-4 mx-2 my-4">
+    <div class="mx-auto max-w-7xl p-4  sm:px-6 lg:p-8">
       <% flash.each do |_key, value| %>
         <div class="text-danger fw-bold my-2">
           <%= value %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -47,7 +47,7 @@
         </div>
       </div>
       <div class="col-span-full">
-        <%= form.submit class: "tw-btn-secondary" %>
+        <%= form.submit class: "tw-btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -27,6 +27,6 @@
   </div>
 
   <div>
-    <%= form.submit %>
+    <%= form.submit, class: "tw-btn-primary" %>
   </div>
 <% end %>


### PR DESCRIPTION
Mostly tailwind styles. Plus a simple vanilla js carousel. We can replace it with a library (maybe [flowbite](https://flowbite.com/docs/components/carousel/)) if we want something fancier. There is not much bootstrap dependency left except for the forms and that is mostly copy/pasting the classes from the profile edit page.

I added artist bio on the bottom of the page because there was a lot of empty space but we can replace that with something else if there is more useful information that doesn't belong to sidebar.

## Screenshots

<details>
   <summary>Before</summary>

Artwork grid: <br/>
<img width="1236" alt="Screen Shot 2024-03-21 at 3 40 16 PM" src="https://github.com/netvvrk/members-database/assets/687513/7e2b286d-f5c8-41ed-8814-50536c7821eb">

Artwork page: <br/>
<img width="1245" alt="Screen Shot 2024-03-21 at 3 40 27 PM" src="https://github.com/netvvrk/members-database/assets/687513/3e29130b-d420-4e27-829f-e886b3cfba24">

</details>

<details>
   <summary>After</summary>

Grid: <br/>
<img width="1169" alt="Screen Shot 2024-03-21 at 3 31 54 PM" src="https://github.com/netvvrk/members-database/assets/687513/f9e56936-942f-46a0-879e-445e6b125f03">

Large screen: <br/>

<img width="1371" alt="Screen Shot 2024-03-22 at 11 09 19 AM" src="https://github.com/netvvrk/members-database/assets/687513/ddebbaef-6b99-473c-bacf-3976dad7faa6">

Small: <br/>


<img width="605" alt="Screen Shot 2024-03-22 at 11 09 33 AM" src="https://github.com/netvvrk/members-database/assets/687513/8c71d6b2-4b0f-4587-8b4c-2fef33c5e8d5">




</details>
