### PR TITLE
Artwork preview tailwind redesign

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -11,17 +11,17 @@
 
   .tw-btn-primary {
     @apply px-2 py-1 border text-slate-700 bg-slate-200 hover:text-black hover:border-black 
-       border-slate-700 rounded-md text-nowrap no-underline;
+       border-slate-700 rounded-md text-nowrap no-underline w-min hover:no-underline;
   }
 
   .tw-btn-secondary {
     @apply px-2 py-1 border text-black hover:text-slate-600 hover:border-slate-400 
-       border-black rounded-md text-nowrap no-underline;
+       border-black rounded-md text-nowrap no-underline w-min hover:no-underline;
   }
 
   .tw-btn-danger {
     @apply px-2 py-1 border text-red-800 hover:text-red-600 border-red-800 
-        hover:border-red-400 rounded-md text-nowrap no-underline;
+        hover:border-red-400 rounded-md text-nowrap no-underline w-min hover:no-underline;
   }
 }
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,7 +8,7 @@ class Image < ApplicationRecord
   before_destroy :purge_file
 
   def is_video?
-    file.blob.content_type.include?("video")
+    file&.blob&.content_type&.include?("video")
   end
 
   private

--- a/app/views/artworks/_image.html.erb
+++ b/app/views/artworks/_image.html.erb
@@ -1,5 +1,5 @@
-<div class="col-4">
-  <%= image_tag large_url(i), alt: i.caption %>
+<div>
+  <%= image_tag large_url(i), alt: i.caption, class: "rounded" %>
   <i><%= i.caption %></i>
   <%= button_to asset_delete_text(i), [@artwork, i], method: :delete, class: "tw-btn-danger btn-sm mt-2 mb-4", form: { data: { turbo_confirm: 'Are you sure?' } } %>
 </div>

--- a/app/views/artworks/show.html.erb
+++ b/app/views/artworks/show.html.erb
@@ -1,56 +1,39 @@
-<div class="container">
-  <%= link_to "preview", preview_artwork_url(@artwork) %>
-  <section class="image-grid mt-2">
-    <div class="row gy-4">
-      <% images = @artwork.images %>
-      <% if images[0] %>
-        <%= render "image", i: images[0] %>
+<div class="flex flex-col lg:grid lg:grid-rows-3 lg:grid-cols-4 gap-6 h-auto">
+  <!-- info -->
+  <div class="lg:col-span-3">
+    <% artwork = @artwork %>
+    <%= render "curator/artworks/info" %>
+  </div>
+  <!-- actions -->
+  <div class="lg:col-start-4 lg:row-start-1 flex content-center lg:flex-col gap-3">
+    <div class=" text-slate-700">
+      <svg width="20" height="20" class="<%= @artwork.visible ? "fill-slate-800" : "fill-slate-300" %>" viewBox="0 0 16 16">
+        <title class="w-full h-full"><%= @artwork.visible ? "" : "Not " %> visible to curators</title>
+        <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+        <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+      </svg>
+    </div>
+    
+      <%= link_to "Preview", preview_artwork_url(@artwork), class: "tw-btn-primary" %>
+    
+    <%= link_to "Edit this artwork", edit_artwork_path(@artwork), class: "tw-btn-secondary" %>
+    <%= button_to "Delete this artwork", @artwork, method: :delete, class: "tw-btn-danger", form: { data: { turbo_confirm: 'Are you sure?' } } %>
+
+  </div>
+  <!-- images -->
+  <div class="mt-4 lg:row-start-2 lg:row-span-2 lg:col-span-4 flex gap-4 lg:gap-6 flex-col lg:flex-row">
+    
+      <% @artwork.images.each do | image |  %>
+      <div>
+        <%= render "image", i: image %>
+      </div>
       <% end %>
-      <% if images[1] %>
-        <%= render "image", i: images[1] %>
-      <% end %>
-      <% if images[2] %>
-        <%= render "image", i: images[2] %>
-      <% end %>
-      <div class="col-3">
-        <% if @artwork.more_images_allowed? %>
-          <h5 class="pink pb-2">Add up to 3 images or videos</h5>
+      <% if @artwork.more_images_allowed? %>
+      <div>
+          <h5>Add a new image</h5>
           <%= render "images/form", artwork: @artwork, image: @artwork.images.new %>
-        <% end %>
-      </div>
-    </div>
-  </section>
-  <div class="row mt-2">
-    <div class="col-4">
-      <div><strong><%= @artwork.title %></strong> (<%= @artwork.year %>)<br>
-        <%= @artwork.medium %>
-      </div>
-      <% if @artwork.edition.present? %>
-        <div>
-          ed: <%= @artwork.edition %>
-        </div>
+      </div> 
       <% end %>
-      <%= render "dimensions" %>
-      <div>
-        Location: <%= @artwork.location %>
-      </div>
-      <div>
-        Price: <%= @artwork.price.present? ? number_to_currency(@artwork.price, unit: "", precision: 0) : "none" %>
-      </div>
-      <div class="pink">
-        <%= @artwork.visible ? "Not " : "" %> Visible to Curators
-      </div>
-      <% if @artwork.description.present? %>
-        <div class="mt-2">
-          <div class="fw-bold">Description</div>
-          <%= @artwork.description %>
-        </div>
-      <% end%>
-    </div>
-    <div class="col-4 mt-2">
-      <%= link_to "Edit this artwork", edit_artwork_path(@artwork), class: "tw-btn-secondary" %>
-      <%= button_to "Delete this artwork", @artwork, method: :delete, class: "tw-btn-danger", form: { data: { turbo_confirm: 'Are you sure?' } }, class: "tw-btn-danger mt-4" %>
-    </div>
+    </div> 
   </div>
 </div>
-<%= javascript_include_tag "lightbox-refresh" %>

--- a/app/views/curator/artworks/_artwork.html.erb
+++ b/app/views/curator/artworks/_artwork.html.erb
@@ -1,5 +1,5 @@
 <div>
-    <a class="text-black" href="<%= curator_artwork_url(artwork) %>">
+    <a class="text-black hover:no-underline" href="<%= curator_artwork_url(artwork) %>">
       <img class="h-auto max-w-full" src="<%= large_url(artwork.images.first) if artwork.images.length %>" alt="<%= artwork.title %>">
       <section class="pt-2">
         <div class=""><%= artwork.user.name %></div>

--- a/app/views/curator/artworks/_info.html.erb
+++ b/app/views/curator/artworks/_info.html.erb
@@ -1,0 +1,28 @@
+<div class="">
+      <h1 class="text-2xl mb-0 font-normal">
+        <%= @artwork.user.name %>
+      </h1>
+      <h2 class="text-2xl font-normal italic text-slate-500">
+        <%= @artwork.title %>, (<%= @artwork.year %>)
+      </h2>
+      <div class="text-slate-500">
+        <%= @artwork.medium %>
+      </div>
+      <% if @artwork.edition.present? %>
+        <div class="text-slate-500">
+          ed: <%= @artwork.edition %>
+        </div>
+      <% end %>
+      <%= render "artworks/dimensions" %>
+      <div class="text-slate-500">
+        Location: <%= @artwork.location %>
+      </div>
+      <div class="text-2xl py-2">
+        Price: <%= @artwork.price.present? ? @artwork.price : "N/A" %>
+      </div>
+      <% if @artwork.description.present? %>
+        <div class="mt-2 text-slate-500">
+          <%= @artwork.description %>
+        </div>
+      <% end%>
+    </div>

--- a/app/views/curator/artworks/show.html.erb
+++ b/app/views/curator/artworks/show.html.erb
@@ -98,35 +98,7 @@
   </div>
 
   <div class="lg:row-start-1 lg:col-start-4 lg:row-span-2">
-    <div class="">
-      <h1 class="text-2xl mb-0 font-normal">
-        <%= @artwork.user.name %>
-      </h1>
-      <h2 class="text-2xl font-normal italic text-slate-500">
-        <%= @artwork.title %>, (<%= @artwork.year %>)
-      </h2>
-      <div class="text-slate-500">
-        <%= @artwork.medium %>
-      </div>
-      <% if @artwork.edition.present? %>
-        <div class="text-slate-500">
-          ed: <%= @artwork.edition %>
-        </div>
-      <% end %>
-      <%= render "artworks/dimensions" %>
-      <div class="text-slate-500">
-        Location: <%= @artwork.location %>
-      </div>
-      <div class="text-2xl py-2">
-        Price: <%= @artwork.price.present? ? @artwork.price : "N/A" %>
-      </div>
-      <% if @artwork.description.present? %>
-        <div class="mt-2 text-slate-500">
-          <div class="fw-bold">Description</div>
-          <%= @artwork.description %>
-        </div>
-      <% end%>
-    </div>
+    <%= render "info" %>
   </div>
   <section class="lg:col-span-3 lg:row-start-3 lg:row-span-4">
       <div class="pb-2">

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -1,6 +1,17 @@
-<%= bootstrap_form_with(model: [artwork, image]) do |f| %>
-  <%= f.alert_message "Please fix the errors below." %>
-  <%= f.text_field :caption, label: "Caption", class: "form-control-sm", help: "required" %>
-  <%= f.file_field :file, class: "form-control-sm" %>
-  <%= f.submit "Save", class: "tw-btn-primary" %>
+<%= form_with(model: [artwork, image]) do |f| %>
+  <div class="flex mt-3 flex-col gap-3">
+    <div class="col-span-full">
+      <%= f.label :caption, 'Caption',  class: "block text-sm font-medium leading-6 text-gray-900" %>
+      <%= f.text_field :caption, class: "block w-full max-w-48 rounded-md border-0 py-1.5 text-gray-900
+                                        ring-1 ring-inset ring-gray-400 placeholder:text-gray-400 focus:ring-2 
+                                        focus:ring-inset focus:ring-indigo-500 sm:text-sm sm:leading-6" %>
+    </div>
+    <div>
+      <%= f.label :file, 'File',  class: "block text-sm font-medium leading-6 text-gray-900" %>
+      <%= f.file_field :file, class: "block w-full p-2 max-w-64 rounded-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-400 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-500 sm:text-sm sm:leading-6" %>
+    </div>
+
+    <%= f.submit "Add", class: "tw-btn-primary" %>
+  </div>
+
 <% end %>


### PR DESCRIPTION
Reused artwork info from the curator artwork page to make them more consistent. Moved all the action buttons to a section (right side on desktop) and converted everything to tailwind.

Before:

<img width="1258" alt="Screen Shot 2024-03-25 at 6 13 16 PM" src="https://github.com/netvvrk/members-database/assets/687513/c872f109-4c61-4ac2-a41f-ae498cf9edb9">


After:

<img width="1301" alt="Screen Shot 2024-03-25 at 6 33 05 PM" src="https://github.com/netvvrk/members-database/assets/687513/1faef1d0-1268-4b53-beb4-2c130c7bbdb5">


Mobile:

<img width="626" alt="Screen Shot 2024-03-25 at 6 33 23 PM" src="https://github.com/netvvrk/members-database/assets/687513/2624f243-f548-4fff-9c4b-8e760473f7dc">
