### PR TITLE
Fixes duplicate artworks in curator artwork page

### DIFF
--- a/app/controllers/curator/artworks_controller.rb
+++ b/app/controllers/curator/artworks_controller.rb
@@ -8,7 +8,8 @@ class Curator::ArtworksController < ApplicationController
     @search_term = params[:search]
     @artworks = Artwork.is_visible.with_images.all.page(@page)
     if @search_term.present?
-      @artworks = @artworks.search(@search_term)
+      # with_pg_search_rank is to avoid sql error (see commit message)
+      @artworks = @artworks.search(@search_term).with_pg_search_rank
       Rails.logger.debug(@artworks.to_sql)
     end
   end

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -15,7 +15,7 @@ class Artwork < ApplicationRecord
   scope :is_visible, -> { where("visible = true") }
 
   scope :with_images, -> {
-                        joins(:images)
+                        joins(:images).distinct(:artwork_id)
                       }
 
   MAX_ARTWORK_IMAGES = 3


### PR DESCRIPTION
`pg_search` creates a complicated long sql query when text search is combined with other ActiveRecord filters. We want either `group by` artworks or have `distinct` artwork ids when checking for artwork images (in `with_images`) to make sure there are not multiple records for artworks with more than one image.  The combination of `order by` for sorting by rank that pg_search adds and the distinct/group statement causes a SQL error because sql doesn't like the order by expression not be in the select expression (in case of `distinct`). 
```
PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...7bb7.pg_search_id WHERE (visible = true) ORDER BY pg_search_...
```
Adding `with_pg_search_rank` (a feature in pg_search mostly for debugging) adds the rank to the select clause and makes sql happy.

the sql ends up being like this:
```sql
SELECT DISTINCT artworks.*, pg_search_043bb1afee0c4dd5437bb7.rank AS pg_search_rank 
FROM "artworks" INNER JOIN "images" ON "images"."artwork_id" = "artworks"."id"
 INNER JOIN (SELECT "artworks"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', 
coalesce("artworks"."title"::text, '')) || to_tsvector('simple', coalesce("artworks"."medium"::text, '')) || 
to_tsvector('simple', coalesce("artworks"."description"::text, '')) || to_tsvector('simple', 
coalesce(pg_search_4aab10cdca183dac25f479.pg_search_acfcdbc0b3d3a65f40eab7::text, '')) || 
to_tsvector('simple', 
coalesce(pg_search_4aab10cdca183dac25f479.pg_search_eeb842708b24d4f7fcf549::text, ''))), 
(to_tsquery('simple', ''' ' || 'bike' || ' ''')), 0)) AS rank FROM "artworks" LEFT OUTER JOIN
 (SELECT "artworks"."id" AS id, "users"."first_name"::text AS pg_search_acfcdbc0b3d3a65f40eab7, 
"users"."last_name"::text AS pg_search_eeb842708b24d4f7fcf549 FROM "artworks"
 INNER JOIN "users" ON "users"."id" = "artworks"."user_id") pg_search_4aab10cdca183dac25f479
 ON pg_search_4aab10cdca183dac25f479.id = "artworks"."id" WHERE ((to_tsvector('simple', 
coalesce("artworks"."title"::text, '')) || to_tsvector('simple', coalesce("artworks"."medium"::text, '')) || 
to_tsvector('simple', coalesce("artworks"."description"::text, '')) || to_tsvector('simple', 
coalesce(pg_search_4aab10cdca183dac25f479.pg_search_acfcdbc0b3d3a65f40eab7::text, '')) || 
to_tsvector('simple', coalesce(pg_search_4aab10cdca183dac25f479.pg_search_eeb842708b24d4f7fcf549::text, '')))
 @@ (to_tsquery('simple', ''' ' || 'bike' || ' ''')))) AS pg_search_043bb1afee0c4dd5437bb7 ON 
"artworks"."id" = pg_search_043bb1afee0c4dd5437bb7.pg_search_id WHERE (visible = true) ORDER
 BY pg_search_043bb1afee0c4dd5437bb7.rank DESC, "artworks"."id" ASC LIMIT $1 OFFSET $2
```
