### PR TITLE
require ostruct

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class MainController < ApplicationController
   # GET /
   def index
@@ -60,13 +62,11 @@ class MainController < ApplicationController
     if !@artwork.visible && !belongs_to_user
       redirect_to root_url
     end
-
   end
 
-  private 
+  private
 
   def belongs_to_user
     current_user&.id == @artwork.user.id
-  end 
-
+  end
 end


### PR DESCRIPTION
This breaks in production without `require "ostruct"`.