### PR TITLE
Active flag for artworks

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -12,7 +12,7 @@ class MainController < ApplicationController
     @has_filters = @min_price.present? || @max_price.present? ||
       @location.present? || @medium.present?
 
-    location_options = Artwork.is_visible.with_images.all.group(:location).order(count: :desc).count
+    location_options = Artwork.is_active.is_visible.with_images.all.group(:location).order(count: :desc).count
 
     @location_options = location_options.each_with_index.reduce([]) do |acc, (item, i)|
       show_by_default = acc.size < 5

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -13,6 +13,7 @@ class Artwork < ApplicationRecord
   pg_search_scope :search, against: [:title, :medium, :description], associated_against: {user: [:first_name, :last_name]}
 
   scope :is_visible, -> { where("visible = true") }
+  scope :is_active, -> { where("active = true") }
 
   scope :with_images, -> {
                         joins(:images).distinct(:artwork_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
 
   def update_artworks
     if !active
-      Artwork.where(user: self).update_all(visible: false)
+      Artwork.where(user: self).update_all(active: false)
     end
   end
 end

--- a/db/migrate/20240621235707_add_active_to_artworks.rb
+++ b/db/migrate/20240621235707_add_active_to_artworks.rb
@@ -1,0 +1,6 @@
+class AddActiveToArtworks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :artworks, :active, :boolean, null: false, default: true
+    add_index :artworks, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_172147) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_21_235707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_172147) do
     t.datetime "updated_at", null: false
     t.integer "year", null: false
     t.string "edition", default: "", null: false
+    t.boolean "active", default: true, null: false
+    t.index ["active"], name: "index_artworks_on_active"
     t.index ["user_id"], name: "index_artworks_on_user_id"
     t.index ["year"], name: "index_artworks_on_year"
   end

--- a/test/models/artwork_test.rb
+++ b/test/models/artwork_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
 class ArtworkTest < ActiveSupport::TestCase
-  test "mark artworks as not visbile if user is deactivated" do
+  test "mark artworks as not active if user is deactivated" do
     user = users(:artist)
-    create_artwork(user)
-    assert_equal 1, Artwork.is_visible.count
+    artwork = create_artwork(user)
+    assert artwork.active
     user.update!(active: false)
-    assert_equal 0, Artwork.is_visible.count
+    refute artwork.reload.active
   end
 
   test "search by artist name" do


### PR DESCRIPTION
We should use `active` not `visible` to hide artworks when a user pauses or cancels their subscription.

