### PR TITLE
Bootstrap remove 1

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,7 +1,7 @@
 $enable-important-utilities: false;
 
-@import "bootstrap/scss/bootstrap";
-@import "bootstrap-icons/font/bootstrap-icons";
+// @import "bootstrap/scss/bootstrap";
+// @import "bootstrap-icons/font/bootstrap-icons";
 // @import "rails_bootstrap_forms";
 
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -28,8 +28,40 @@
     @apply block rounded-md border-0 text-gray-900 ring-1 ring-inset ring-gray-400 placeholder:text-gray-400 focus:ring-2 sm:text-sm
   }
 
+  .form-label {
+    @apply block text-sm font-medium leading-6 text-gray-900
+  }
+
+  .form-desc {
+    @apply text-gray-600 text-sm
+  }
+
   .tw-page-link {
     @apply flex items-center justify-center text-nowrap px-3 md:px-4 h-10 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white
+  }
+
+  .table {
+    @apply text-sm text-left rtl:text-right
+  }
+
+  .table thead tr {
+    @apply border-b border-slate-500 
+  }
+
+  .table td, .table th {
+    @apply px-2
+  }
+
+  .table tbody td {
+    @apply content-start
+  }
+
+  .table tbody tr {
+    @apply border-b border-slate-200 
+  }
+
+  .table tbody td {
+    @apply  py-4
   }
 
   .tw-page-current {

--- a/app/javascript/locationsearch.js
+++ b/app/javascript/locationsearch.js
@@ -28,15 +28,16 @@ async function fetchSuggestions(e) {
      `<li data-place-name="${suggestion.name}" class="p-2 cursor-pointer ${i % 2 ? "bg-slate-200" : ""}">${suggestion.name}, ${suggestion.place_formatted}</li>`).join("") 
      : ""
     suggestionEl.innerHTML = lineItems
-    suggestionEl.classList.remove('opacity-0', )
-    suggestionEl.classList.remove('h-0')
+    suggestionEl.classList.remove('opacity-0')
+    suggestionEl.classList.remove('hidden')
     suggestionEl.querySelectorAll('li').forEach(item => item.addEventListener('click', e => {
         const value = e.target.getAttribute('data-place-name')
         autofillEl.value = value
         locationHiddenEl.value = value
-        suggestionEl.classList.add('opacity-0', )
-        suggestionEl.classList.add('h-0')
-        }))
+        suggestionEl.classList.add('opacity-0')
+        setTimeout(() =>  suggestionEl.classList.add('hidden'), 200)
+       
+    }))
 }
 
 const debouncedFetch = debounce(fetchSuggestions, 500)

--- a/app/views/artworks/_form.html.erb
+++ b/app/views/artworks/_form.html.erb
@@ -1,12 +1,42 @@
-  <%= bootstrap_form_with(model: artwork) do |f| %>
-  <div class="max-w-md">
-    <%= f.alert_message "Please fix the errors below." %>
-    <%= f.text_field :title, class: "small-field", help: "required" %>
-    <%= f.text_field :medium, class: "small-field", help: "required" %>
-    <%= f.text_field :edition, class: "small-field", help: "if applicable" %>
-    <%= f.text_area :description, rows: 6, class: "small-field" %>
-    <%= f.number_field :year, class: "small-field", help: "required" %>
-    <%= f.number_field :price, class: "small-field" %>
+  <%= form_with(model: artwork) do |f| %>
+  <div class="max-w-md grid grid-cols-1 gap-y-6 ">
+    <% if artwork.errors.any? %>
+      <div class="text-red-500 my-4 w-full border-red-200 py-2 border-b">
+        <ul>
+          <% artwork.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>  
+    <div>
+      <%= f.label :title, class: "form-label" %>
+      <%= f.text_field :title, class: "small-field w-full" %>
+      <span class="form-desc">required</span>
+    </div>
+    <div>
+      <%= f.label :medium, class: "form-label" %>
+      <%= f.text_field :medium, class: "small-field w-full" %>
+      <span class="form-desc">required</span>
+    </div>
+    <div>
+      <%= f.label :edition, class: "form-label" %>
+      <%= f.text_field :edition, class: "small-field w-full" %>
+      <span class="form-desc">if applicable</span>
+    </div>
+    <div>
+      <%= f.label :description, class: "form-label" %>
+      <%= f.text_area :description, rows: 6, class: "small-field w-full" %>
+    </div>
+    <div>
+      <%= f.label :year, class: "form-label" %>
+      <%= f.number_field :year, class: "small-field w-full" %>
+      <span class="form-desc">required</span>
+    </div>
+    <div>
+      <%= f.label :price, class: "form-label" %>
+      <%= f.number_field :price, class: "small-field" %>
+    </div>
     <div class="flex flex-col">
       <label>Location</label>
       <span class="text-sm text-slate-700 my-2">
@@ -14,22 +44,39 @@
       </span>
       <input type="text" class="small-field" value="<%= artwork.location %>" id="location-search"/>
       <%= f.hidden_field :location, id: "location-hidden" %>
-      <span class="text-sm text-slate-700 my-2">required</span>
+      <span class="form-desc my-2">required</span>
     
-      <ul id="suggestion-container" class="my-3 opacity-0 transition-opacity flex flex-col border-1 rounded border-slate-400 gap-2">
+      <ul id="suggestion-container" class="opacity-0 transition-opacity flex flex-col border rounded border-slate-400 gap-2">
         <li class="hidden p-2 cursor-pointer bg-slate-200">test</li>
       </ul>
     </div>
-    <fieldset class="mb-6">
-      <p class="text-secondary mb-2">Artwork visibility</p>
+    <fieldset class="">
+      <label class="form-label">Artwork visibility</label>
       <%= f.check_box :visible, label: "Visible to curators" %>
+      <%= f.label(:visible, "Visible to curators") %>
     </fieldset>
-    <fieldset class="border round-sm p-2 mb-4 max-w-80">
-      <%= f.number_field :duration, label: "Duration (minutes)", class: "small-field" %>
-      <%= f.select :units, %w[in cm], class: "small-field" %>
-      <%= f.number_field :height, class: "small-field" %>
-      <%= f.number_field :width, class: "small-field" %>
-      <%= f.number_field :depth, class: "small-field" %>
+    <fieldset class="border round-sm p-3 grid gap-y-3 mb-4 max-w-96">
+      <p class="form-desc">Either duration or heigh and width are required</p>
+      <div>
+        <%= f.label(:duration, :class => "form-label") %>
+        <%= f.number_field :duration, label: "Duration (minutes)", class: "small-field" %>
+      </div>
+      <div>
+        <%= f.label(:units, :class => "form-label") %>
+        <%= f.select :units, %w[in cm], class: "small-field" %>
+      </div>
+      <div>
+        <%= f.label(:height, :class => "form-label") %>
+        <%= f.number_field :height, class: "small-field" %>
+      </div>
+      <div>
+        <%= f.label(:width, :class => "form-label") %>
+        <%= f.number_field :width, class: "small-field" %>
+      </div>
+      <div>
+        <%= f.label(:depth, :class => "form-label") %>
+        <%= f.number_field :depth, class: "small-field" %>
+      </div>
     </fieldset>
     <%= f.submit "Save", class: "tw-btn-primary" %>
   <% end %>

--- a/app/views/artworks/_form.html.erb
+++ b/app/views/artworks/_form.html.erb
@@ -38,7 +38,7 @@
       <%= f.number_field :price, class: "small-field" %>
     </div>
     <div class="flex flex-col">
-      <label>Location</label>
+      <label class="form-label">Location</label>
       <span class="text-sm text-slate-700 my-2">
       Search locations (City, state, and country), then select from box
       </span>
@@ -55,15 +55,14 @@
       <%= f.check_box :visible, label: "Visible to curators" %>
       <%= f.label(:visible, "Visible to curators") %>
     </fieldset>
-    <fieldset class="border round-sm p-3 grid gap-y-3 mb-4 max-w-96">
-      <p class="form-desc">Either duration or heigh and width are required</p>
+    <fieldset class="border round-sm p-3 grid gap-y-2 mb-4 max-w-96">
       <div>
-        <%= f.label(:duration, :class => "form-label") %>
-        <%= f.number_field :duration, label: "Duration (minutes)", class: "small-field" %>
+        <%= f.label(:duration, "Duration (minutes)", :class => "form-label") %>
+        <%= f.number_field :duration, class: "small-field" %>
       </div>
       <div>
         <%= f.label(:units, :class => "form-label") %>
-        <%= f.select :units, %w[in cm], class: "small-field" %>
+        <%= f.select :units, %w[in cm], {}, { class: "small-field" } %>
       </div>
       <div>
         <%= f.label(:height, :class => "form-label") %>

--- a/app/views/artworks/index.html.erb
+++ b/app/views/artworks/index.html.erb
@@ -3,15 +3,15 @@
 <% if current_user.more_artworks_allowed? %>
   <%= link_to "Add new artwork", new_artwork_path, class: "tw-btn-secondary inline-block my-3" %>
 <% end %>
-<table class="table">
+<table class="table mt-6">
   <thead  class="text-sm">
     <tr>
       <th>ID</th>
       <th>Title</th>
       <th>Medium</th>
       <th class="hidden sm:table-cell">Description</th>
-      <th>Visible to curators?</th>
-      <th>&nbsp;</th>
+      <th>Visible</th>
+      <th>Images</th>
       <th>&nbsp;</th>
     </tr>
   </thead>

--- a/app/views/artworks/show.html.erb
+++ b/app/views/artworks/show.html.erb
@@ -6,7 +6,7 @@
   </div>
   <!-- images -->
   <h3 class="mt-4 text-xl">Images</h3>
-  <div class="border-slate-300 border-1 p-4 flex gap-4 lg:gap-6 flex-col sm:flex-row sm:flex-wrap">
+  <div class="border-slate-300 border p-4 flex gap-4 lg:gap-6 flex-col sm:flex-row sm:flex-wrap">
     
       <% @artwork.images.each do | image |  %>
       <div class="sm:w-[calc(50%-15px)] lg:w-[calc(33%-15px)]">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="container col-md-3">
+<div class="container max-w-80">
   <h4>Change your password</h4>
   <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
     <%= f.hidden_field :reset_password_token %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,9 +1,15 @@
-<div class="container max-w-80">
+<div class="mx-auto max-w-80">
   <h4>Change your password</h4>
-  <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
     <%= f.hidden_field :reset_password_token %>
-    <%= f.password_field :password, label: "New password", autofocus: true %>
-    <%= f.password_field :password_confirmation, label: "Confirm new password" %>
+    <div class="mb-4">
+      <%= f.label :password, "New password", class: "form-label" %>
+      <%= f.password_field :password, class: "small-field w-full", autofocus: true %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :password_conformation, "Confirm new password", class: "form-label" %>
+      <%= f.password_field :password_confirmation, class: "small-field w-full" %>
+    </div>
     <%= f.submit "Change my password", class: "tw-btn-primary" %>
   <% end %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,13 +1,11 @@
-<div class="container max-w-80">
+<div class="mx-auto max-w-80">
   <h4>Forgot your password?</h4>
-  <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name)) do |f| %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
-    <div class="my-6">
-      <%= f.email_field :email, class: "small-field", autofocus: true, autocomplete: "email", label: "E-mail address"  %>
+    <div class="my-8">
+      <%= f.label :email, "Email address", class: "form-label mb-1" %>
+      <%= f.email_field :email, class: "small-field w-full", autofocus: true, autocomplete: "email" %>
     </div>
-    <%= f.submit "Send me reset password instructions", class: "tw-btn-primary" %>
+    <%= f.submit "Send me reset password instructions", class: "tw-btn-primary w-full" %>
   <% end %>
-  <div class="mt-4">
-    <%= render "devise/shared/links" %>
-  <div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,17 @@
-<div class="container max-w-72">
-  <%= bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <%= f.email_field :email, label: "E-mail address", class: "small-field" %>
-    <%= f.password_field :password, class: "small-field" %>
-    <%= f.check_box :remember_me %>
+<div class="mx-auto w-full max-w-80">
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="mb-4">
+      <%= f.label :email, class: "form-label" %>
+      <%= f.email_field :email, label: "E-mail address", class: "w-full small-field" %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :password, class: "form-label" %>
+      <%= f.password_field :password, class: "w-full small-field" %>
+    </div>
+    <div class="mb-4">
+      <%= f.check_box :remember_me, class: "mr-2" %>
+      <%= f.label :remember_me, class: "form-label inline" %>
+    </div>
     <%= f.submit "Log In", class: "tw-btn-primary" %>
   <% end %>
   <%= render "devise/shared/links" %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white shadow-md shadow-slate-200 border-b-slate-200 border-1">
+<nav class="bg-white shadow-md shadow-slate-200 border-b-slate-200 border">
   <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
     <div class="relative flex h-16 items-center justify-between">
       <div class="flex flex-1 items-center justify-between sm:items-stretch ">
@@ -14,7 +14,7 @@
           <input class="peer hidden" type="checkbox" id="mobile-menu" />
           <!-- mobile menu icon. -->
           <div class="lg:hidden relative z-50 block h-[1px] w-7 bg-black bg-transparent content-[''] before:absolute before:top-[-0.35rem] before:z-50 before:block before:h-full before:w-full before:bg-black before:transition-all before:duration-200 before:ease-out before:content-[''] after:absolute after:right-0 after:bottom-[-0.35rem] after:block after:h-full after:w-full after:bg-black after:transition-all after:duration-200 after:ease-out after:content-[''] peer-checked:bg-transparent before:peer-checked:top-0 before:peer-checked:w-full before:peer-checked:rotate-45 before:peer-checked:transform after:peer-checked:bottom-0 after:peer-checked:w-full after:peer-checked:-rotate-45 after:peer-checked:transform"></div>
-          <div class="lg:flex lg:flex-1 bg-white border-l-slate-200 border-1 lg:border-white lg:ml-6  lg:static lg:top-auto lg:translate-x-0 fixed top-0 right-0 z-40 h-full w-full translate-x-full overflow-y-auto overscroll-y-none transition duration-500 peer-checked:translate-x-1 peer-checked:sm:translate-x-1/3 peer-checked:md:translate-x-1/2">
+          <div class="lg:flex lg:flex-1 bg-white border-l-slate-200 border lg:border-white lg:ml-6  lg:static lg:top-auto lg:translate-x-0 fixed top-0 right-0 z-40 h-full w-full translate-x-full overflow-y-auto overscroll-y-none transition duration-500 peer-checked:translate-x-1 peer-checked:sm:translate-x-1/3 peer-checked:md:translate-x-1/2">
             <div class="flex lg:flex-1 flex-col pt-12 lg:pt-0 lg:flex-row">
               <% if user_signed_in? %>
                 <% if current_user.show_artworks? %>

--- a/app/views/main/_header.html.erb
+++ b/app/views/main/_header.html.erb
@@ -43,7 +43,7 @@
       <!-- filter menu -->
       <div class="top-0  right-0 fixed z-10 h-full w-full translate-x-full overflow-y-auto overscroll-y-none transition duration-500 peer-checked/filter:translate-x-1 peer-checked/filter:sm:translate-x-1/3 peer-checked/filter:md:translate-x-1/2">
         <div class="pt-16 bg-white"></div>
-        <div class="flex flex-col gap-6 p-6 bg-white border-l-slate-400 border-1">
+        <div class="flex flex-col gap-6 p-6 bg-white border-l-slate-400 border">
           <h3>Filter artworks</h4>
           <%= form_with method: :get do |f| %>
             <div class="flex flex-col gap-4">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_with(model: profile) do |form| %>
   <% if profile.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(profile.errors.count, "error") %> prohibited this profile from being saved:</h2>
+    <div class="text-red-500 my-4">
       <ul>
         <% profile.errors.each do |error| %>
           <li><%= error.full_message %></li>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -6,8 +6,10 @@
       profile_path(Profile.find_or_create_by(user_id: user.id))
       ) %>
     </td>
-    <td><%= link_to user.cb_customer_id, "https://#{Rails.configuration.x.chargebee.site}.chargebee.com/d/customers/#{user.cb_customer_id}" %></td>
-    <td><%= user.email %></td>
+    <td class="max-w-24 sm:max-w-40 md:max-w-fit text-ellipsis overflow-hidden">
+      <%= link_to user.cb_customer_id, "https://#{Rails.configuration.x.chargebee.site}.chargebee.com/d/customers/#{user.cb_customer_id}" %>
+    </td>
+    <td class="max-w-24 sm:max-w-40 md:max-w-fit text-ellipsis overflow-hidden"><%= user.email %></td>
     <td><%= user.role %></td>
     <td><%= yesno(user.active) %></td>
     <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,12 +1,9 @@
-<h1 class="text-xl">Artworks</h1>
-<div class="flex-1 flex justify-end gap-3 items-center ">
-  <% if @has_filters %>
-    <%= link_to "/", class: "tw-btn-primary text-sm" do %>
-      clear all filters
-    <% end %>
-  <% else %>
+<div class="flex justify-between items-center my-6">
+  <h1 class="text-xl">Users</h1>
+  <div class="flex-1 flex justify-end gap-3 items-center" >
     <%= form_with method: :get do |f| %>
-      <%= f.text_field :search, value: @search_term, placeholder: "search", label: '&nbsp;'.html_safe, class: "w-40 h-8 rounded focus:w-56 transition-[width] duration-300"   %>
+      <%= f.text_field :search, value: @search_term, placeholder: "search users", label: '&nbsp;'.html_safe, 
+          class: "w-40 h-8 rounded focus:w-56 transition-[width] duration-300"   %>
     <% end %>
     <% if @search_term.present? %>
       <%= link_to users_path do %>
@@ -15,14 +12,15 @@
         </svg>
       <% end %>
     <% end %>
-  <% end %>
+  </div>
+
 </div>
-<table id="users" class="table">
+<table id="users" class="table w-full mt-6">
   <thead>
     <tr>
       <th scope="col">Name</th>
-      <th scope="col">ID</th>
-      <th scope="col">E-mail</th>
+      <th scope="col" class="max-w-40 sm:max-w-fit text-ellipsis overflow-hidden">ID</th>
+      <th scope="col" class="max-w-40 sm:max-w-fit text-ellipsis overflow-hidden">E-mail</th>
       <th scope="col">Role</th>
       <th scope="col">Active</th>
       <th scope="col">&nbsp;</th>


### PR DESCRIPTION
In this PR:
* Fix for `visible to curators` checkbox bug (it was due to invisible location search autocomplete blocking the checkbox)
* Remove `bootstrap_form_for` from artwork page. Mostly had to create labels separately for each field.
* Add tailwind table styles (for Artwork list and User list)
* Styling user page. In mobile view long columns wrap
* Max with for change password page
* Remove `bootstrap_form_for` from login page
* Remove `bootstrap_form_for` from forgot password page
* Remove `bootstrap_form_for` from new password page (TODO: test on staging)
* Soft delete bootstrap styles. 

**Didn't remove bootstrap completely in case we want to bring it back. Just commented the style includes.**