### PR TITLE
When there are too many locations dont show 'more' in filters

### DIFF
--- a/app/javascript/filter.js
+++ b/app/javascript/filter.js
@@ -26,7 +26,7 @@ function addSearch(inputEl, items) {
 }
 
 function addExpand(btn, items) {
-    btn.addEventListener('click', () => {
+    btn && btn.addEventListener('click', () => {
         const isOpen = btn.getAttribute('data-open')
         items.forEach((item, i) => {
             if( isOpen == null ) {

--- a/app/views/main/_header.html.erb
+++ b/app/views/main/_header.html.erb
@@ -74,8 +74,12 @@
                         </label>
                       </div>
                     <% end %>
-                    <% if @location_options.length > 5 %>
+                    <% if @location_options.length > 5 and @location_options.length < 20  %>
                       <label id="location-more" class="text-slate-500 my-2 w-content cursor-pointer text-sm">show all</label>
+                    <% elsif @location_options.length > 20 %>
+                      <label id="location-too-many" class="text-slate-500 my-2 w-1/2 text-sm">
+                        There are too many locations (Showing only top 5). Use search to find the location.
+                      </label>
                     <% end %>
                   </div>
                 </div>


### PR DESCRIPTION
Problem: when there are too many locations the list is too long to be able to collapse it or go through the list. also the filter sidebar gets too long that the white background is no longer covering the sidebar.

It is bad UX and impossible to collapse after opening. instead use search.