### PR TITLE
Add `persisted?` check to profile attachment.

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -43,7 +43,7 @@
       <div class="col-span-full">
         <%= form.label :avatar, "Profile picture", class: "block text-sm font-medium leading-6 text-gray-900 mb-2" %>
         <div class="block w-full max-w-96 lg:w-1/2">
-          <% if profile.avatar.attached? %>
+          <% if profile.avatar.attached? && profile.avatar.persisted? %>
             <div class="text-sm my-2">
               Current picture:
             </div>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id profile %>" class="lg:grid lg:auto-rows-min lg:grid-cols-12 lg:gap-x-8">
   <div class="bg-slate-100 mt-8 p-6 lg:min-h-vh rounded-lg flex flex-1 gap-y-4 flex-col lg:col-span-4 lg:col-start-1 lg:row-span-3 lg:row-start-1 lg:mt-0">
-    <% if profile.avatar.attached? %>
+    <% if profile.avatar.attached? && profile.avatar.persisted? %>
       <div class="w-full sm:w-auto my-2">
         <%= image_tag profile.avatar %>
       </div>
@@ -49,7 +49,7 @@
         </svg>
       </a>
     </div>
-    <% if profile.cv.attached? %>
+    <% if profile.cv.attached? && profile.cv.persisted? %>
       <div class="my-3">
         <a href="<%= profile.cv.url %>" target="_blank" class="block tw-btn-secondary text-center w-32">CV</a>
       </div>


### PR DESCRIPTION
Even when avatar/cv validation fails the `attached?` flag remains set so it is not enough to check if it really exists

source: https://stackoverflow.com/questions/60083633/active-storage-still-detects-attachement-even-after-validation-failure
and: https://github.com/rails/rails/issues/50234

fixes: https://app.honeybadger.io/projects/125810/faults/114468008