### PR TITLE
NVK-80 medium/location counts don't update when there is a filter

### DIFF
--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -30,6 +30,11 @@ class Artwork < ApplicationRecord
   scope :with_images, -> {
                         joins(:images).distinct(:artwork_id)
                       }
+  
+  scope :has_max_price, -> (price) {  where("price < ? ", price) }
+  scope :has_min_price, -> (price) {  where("price > ? ", price) }
+  scope :has_medium, -> (medium) { where("medium in (?) ", medium) }
+  scope :has_location, -> (location) { where("location in (?) ", location) }
 
   def artist_name
     user.profile.name

--- a/app/views/main/_header.html.erb
+++ b/app/views/main/_header.html.erb
@@ -76,7 +76,7 @@
                     <% end %>
                     <% if @location_options.length > 20 %>
                       <label id="location-too-many" class="text-slate-500 my-2 w-1/2 text-sm">
-                        There are too many locations (Showing only top 5). Use search to find the location.
+                        Use search to find other locations.
                       </label>
                     <% end %>
                   </div>


### PR DESCRIPTION
Problem: when there is a filter or search term the counts for locations/medium don't update accordingly

Solution: apply the filter to the list of artworks before grouping them by `'location` and `medium` to get the count